### PR TITLE
Fix CSS typo in leads_form template

### DIFF
--- a/templates/leads_form.html
+++ b/templates/leads_form.html
@@ -8,7 +8,7 @@
  label{display:block;margin-top:12px;}
  input,select,textarea{width:100%;padding:8px;border-radius:4px;border:1px solid #444;background:#111;color:#fff;}
  textarea{height:100px;resize:vertical;}
- .btn{display:inline-block;margin-top:18px;padding:10px 18px;background:#555;color:#fff;border:none;borderradius:6px;text-decoration:none;cursor:pointer;}
+ .btn{display:inline-block;margin-top:18px;padding:10px 18px;background:#555;color:#fff;border:none;border-radius:6px;text-decoration:none;cursor:pointer;}
  .msg{color:#ff6666;margin-top:10px;text-align:center;}
  .top{text-align:center;margin-bottom:10px;}
 </style>


### PR DESCRIPTION
## Summary
- fix the `.btn` class border-radius typo in `leads_form.html`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ae8dd63a88324bc88a5880732bfc7